### PR TITLE
fix postgresql 9.4 / php 5.5 issues

### DIFF
--- a/plphp.c
+++ b/plphp.c
@@ -49,6 +49,7 @@
 #include "postgres.h"
 #include "access/heapam.h"
 #include "access/transam.h"
+#include "access/htup_details.h"
 
 #include "catalog/catversion.h"
 #include "catalog/pg_language.h"
@@ -566,7 +567,7 @@ plphp_call_handler(PG_FUNCTION_ARGS)
 				desc = plphp_compile_function(fcinfo->flinfo->fn_oid, true TSRMLS_CC);
 
 				/* Activate PHP safe mode if needed */
-				PG(safe_mode) = desc->trusted;
+				//PG(safe_mode) = desc->trusted;
 
 				retval = plphp_trigger_handler(fcinfo, desc TSRMLS_CC);
 			}
@@ -575,7 +576,7 @@ plphp_call_handler(PG_FUNCTION_ARGS)
 				desc = plphp_compile_function(fcinfo->flinfo->fn_oid, false TSRMLS_CC);
 
 				/* Activate PHP safe mode if needed */
-				PG(safe_mode) = desc->trusted;
+				//PG(safe_mode) = desc->trusted;
 
 				if (desc->retset)
 					retval = plphp_srf_handler(fcinfo, desc TSRMLS_CC);

--- a/plphp_io.c
+++ b/plphp_io.c
@@ -20,6 +20,7 @@
 #include "utils/rel.h"
 #include "utils/syscache.h"
 #include "utils/memutils.h"
+#include "access/htup_details.h"
 
 /*
  * plphp_zval_from_tuple

--- a/plphp_spi.c
+++ b/plphp_spi.c
@@ -40,6 +40,7 @@
 
 /* PostgreSQL stuff */
 #include "access/xact.h"
+#include "access/htup_details.h"
 #include "miscadmin.h"
 
 #undef DEBUG_PLPHP_MEMORY


### PR DESCRIPTION
enable usage og PLphp in postgresql 9.4 instance with php 5.5 library
